### PR TITLE
Fix code element not assuming full width of parent

### DIFF
--- a/app/styles.source.css
+++ b/app/styles.source.css
@@ -333,8 +333,7 @@ html.dark {
   }
 
   & pre code {
-    display: grid;
-    max-width: auto;
+    display: inline-block;
     padding: 0;
     margin: 0;
     overflow: visible;
@@ -343,6 +342,7 @@ html.dark {
     background-color: initial;
     border: 0;
     border-radius: initial;
+    min-width: 100%
   }
 
   & pre[data-line-numbers="true"]:not([data-lang="bash"], [data-lang="sh"]) {


### PR DESCRIPTION
# Description

This pull request resolves the issue of the `code` element not assuming the full width of its parent element (`pre`), thereby causing the highlighting `span` elements (children of the `code` element) not to span the entire length of the code they are highlighting.

The issue occurred because the `code` element is an inline property, which means it flows with surrounding text. However, by setting the display property to inline-block, we can change the display behavior of the element to behave like a block-level element, allowing us to set the width and height properties.

To ensure that the code element assumes the width of its parent container, we explicitly set the min-width property to 100%. This allows the `code` element to expand to the full available width of its parent element (`pre`), resorting to the code highlighter spanning the entire line of code where it is applied

I have included screenshots of before and after the fix on both desktop and mobile views below.

# Screenshots

## Before Fix: Desktop View
![before-fix-desktop-view](https://user-images.githubusercontent.com/99342564/235901175-0fe64b64-1178-4866-94fb-dbcde1edb9db.png)


## After Fix: Desktop View
![desktop-view](https://user-images.githubusercontent.com/99342564/235901310-4306165c-020a-4659-95fa-d0fd0fc5b145.png)

## After Fix: Mobile View
![mobile-view](https://user-images.githubusercontent.com/99342564/235901433-a13dd2b4-8088-4e4f-abea-5f574763ed24.png)

# Pull Request Reference
This pull request is based on issue from this pull request #33.
